### PR TITLE
Add live charts for voltage and current output

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "crc": "^4.3.2",
     "next": "14.0.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "chart.js": "^4.0.0",
+    "react-chartjs-2": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,7 +46,7 @@ interface IDP100Props {
   device: HIDDevice,
 }
 
-const chartOptions: ChartOptions = {
+const chartOptions: ChartOptions<"line"> = {
   responsive: true,
   plugins: {
     legend: {
@@ -74,6 +74,8 @@ const chartOptions: ChartOptions = {
 };
 
 interface ChartData {
+  isVisible: boolean,
+  isCapturing: boolean,
   maxDataPoints: number,
   timestamps: Date[],
   currents: number[],
@@ -81,6 +83,8 @@ interface ChartData {
 }
 
 const chartValues: ChartData = {
+  isVisible: false,
+  isCapturing: true,
   maxDataPoints: 1000,
   timestamps: [],
   currents: [],
@@ -118,7 +122,7 @@ const DP100: React.FC<IDP100Props> = ({device}) => {
     basicInfo.out_mode === 2 ? 'OFF' : basicInfo.out_mode === 1 ? 'CV' : basicInfo.out_mode === 0 ? 'CC' : basicInfo.out_mode === 130 ? 'UVP' : 'unknown'
 
   // Collect chart data.
-  if (basicInfo) {
+  if (basicInfo && chartValues.isCapturing) {
     if (chartValues.currents.length > chartValues.maxDataPoints) {
       chartValues.timestamps.shift()
       chartValues.currents.shift();
@@ -133,14 +137,14 @@ const DP100: React.FC<IDP100Props> = ({device}) => {
     labels: chartValues.timestamps.map((v, _) => `${v.getHours()}:${v.getMinutes()}:${v.getSeconds()}.${v.getMilliseconds()}`),
     datasets: [
       {
-        label: 'Currents',
+        label: 'Current',
         data: chartValues.currents,
         borderColor: 'rgb(255, 99, 132)',
         backgroundColor: 'rgba(255, 99, 132, 0.5)',
         yAxisID: 'y',
       },
       {
-        label: 'Voltages',
+        label: 'Voltage',
         data: chartValues.voltages,
         borderColor: 'rgb(132, 99, 132)',
         backgroundColor: 'rgba(132, 99, 132, 0.5)',
@@ -148,6 +152,9 @@ const DP100: React.FC<IDP100Props> = ({device}) => {
       },
     ],
   };
+
+  const graphVisibleText = chartValues.isVisible ? "Hide graphs" : "Show graphs";
+  const graphCapturingVisibleText = chartValues.isCapturing ? "Pause": "Resume";
 
   return (
     <>
@@ -215,7 +222,19 @@ const DP100: React.FC<IDP100Props> = ({device}) => {
       )}
     </div>
     <br />
-    <Line options={chartOptions} data={chartData} />;
+    <div>
+      <button onClick={() => chartValues.isVisible = !chartValues.isVisible}>{graphVisibleText}</button>
+      {chartValues.isVisible && (
+        <div>
+        <button style={{marginLeft: 10}} onClick={() => chartValues.isCapturing = !chartValues.isCapturing}>
+          {graphCapturingVisibleText
+        }</button>
+        </div>
+      )}
+      {chartValues.isVisible && (
+        <Line options={chartOptions} data={chartData} />
+      )}
+    </div>
     </>
   )
 }


### PR DESCRIPTION
This PR introduces a toggleable graph (default off) to the webpage. This plots Voltage and Current out, collected every time there is a data point.

This is my first PR using React, so my apologies for probably not the most idiomatic code.

Thanks!

Preview:
![image](https://github.com/scottbez1/webdp100/assets/116215/8fd62bd2-0e68-41a9-ad09-9e537799251d)
